### PR TITLE
Bug was fixed

### DIFF
--- a/blob_cgo.go
+++ b/blob_cgo.go
@@ -107,11 +107,10 @@ func (buf *BlobBuf) AddDouble(name string, val float64) int {
 
 // Head return the front BlobAttr (head filed) of BlobBuf
 func (buf *BlobBuf) Head() *BlobAttr {
-	if buf.head == nil {
-		buf.head = &BlobAttr{
-			ptr: buf.ptr.head,
-		}
+	buf.head = &BlobAttr{
+		ptr: buf.ptr.head,
 	}
+	
 	return buf.head
 }
 


### PR DESCRIPTION
When blob buffer is growing, libubox library allocate memory space at new address, so the Head pointer has to be changed not only at first time, but always when method Head() is called.